### PR TITLE
fix: reverted changes on scrape button

### DIFF
--- a/src/resources/ui/components/button.scrape.tsx
+++ b/src/resources/ui/components/button.scrape.tsx
@@ -1,49 +1,46 @@
 import React, { useEffect, useState } from "react"
 import { eventScrape } from "~resources/ui/actions/event.scrape";
 import { Button } from "@heroui/button";
-import { ArchiveBoxArrowDownIcon} from "@heroicons/react/16/solid";
+import { ArchiveBoxArrowDownIcon } from "@heroicons/react/16/solid";
 import { ScrapeStatus } from "~resources/domain/enums/status.dbo";
 import statusColors from "~resources/ui/colors/status";
 import type { UseButtonProps } from "@heroui/button/dist/use-button"
 import { sendToBackground } from "@plasmohq/messaging"
-import { addToast } from "@heroui/react"
-import { useEvent } from "~resources/ui/providers/event"
-import type { EventModel } from "~resources/domain/models/event.model"
-import type { EventOrganizerDbo } from "~resources/domain/dbos/event.organizer.dbo"
 
 type ScrapButtonProps = {
-  event?: Pick<EventModel, "id" | "lastUpdated"> & { status: { scrape: ScrapeStatus}, organizer: Pick<EventOrganizerDbo, "id"> },
-  notifiable?: boolean;
-  useOnClick?: boolean;
+  eventId?: string;
+  organizationId?: string;
 } & UseButtonProps;
 
-const ButtonScrape: React.FC<ScrapButtonProps> = ({event, notifiable = false, useOnClick=false, ...props}: ScrapButtonProps) => {
-  const { event: eventFromContext } = useEvent();
-  const currentEvent = event ?? eventFromContext;
-
+const ButtonScrape: React.FC<ScrapButtonProps> = ({eventId, organizationId, ...props}: ScrapButtonProps) => {
   const [scrapeStatus, setScrapeStatus] = useState<ScrapeStatus>(ScrapeStatus.NOT_STARTED);
   const [isScraping, setIsScraping] = useState(false);
-  const [hasFailed, setHasFailed] = useState<string | null>(null);
+  const [isFetching, setIsFetching] = useState(false);
 
   useEffect(() => {
-    setScrapeStatus(currentEvent.status.scrape);
-  }, [currentEvent]);
+    if (eventId) {
+      loadScrapeStatus();
+    }
+
+    async function loadScrapeStatus () {
+      setIsFetching(true);
+      try {
+        const event = await sendToBackground({ name: 'back/event-get', body: { eventId }});
+        setScrapeStatus(event.status.scrape);
+      } catch (error) {
+        console.error("Failed to fetch event status:", error);
+      }
+      setIsFetching(false);
+    }
+  }, [eventId]);
 
   const handleScrape = async () => {
     setIsScraping(true);
     try {
-      const scrapedEvent = await eventScrape(event.id, event.organizer.id, !!event.lastUpdated);
-      setScrapeStatus(scrapedEvent.status.scrape);
+      const event = await eventScrape(eventId, organizationId);
+      setScrapeStatus(event.status.scrape);
     } catch (error) {
-      if (notifiable) {
-        addToast({
-          title: "Failed to scrape event",
-          description: error.message,
-          hideIcon: true,
-          color: "danger"
-        });
-      }
-      setHasFailed(error.message)
+      console.error("Scraping failed:", error);
     }
     setIsScraping(false);
   };
@@ -60,19 +57,19 @@ const ButtonScrape: React.FC<ScrapButtonProps> = ({event, notifiable = false, us
     return "Scrape data from this event, it will be then available for pairing!";
   };
 
-  let className = ` ${props.className}`
+  let className = `bg-blue-600 text-white rounded-md gap-2 ${props.className}`
+
   if (!props.isIconOnly) {
-    className += "px-4 py-2 flex items-center justify-center";
+    className += " px-4 py-2 flex items-center justify-center";
   }
 
-  if (!currentEvent) return
-  if (hasFailed) return
+  if (!eventId) return;
 
   return (
     <Button
       {...props}
-      {...(useOnClick ? { onClick: handleScrape } : { onPress: handleScrape })}
-      disabled={isScraping}
+      onClick={handleScrape}
+      disabled={isScraping || isFetching}
       size="md"
       className={className}
       color="primary"
@@ -84,64 +81,5 @@ const ButtonScrape: React.FC<ScrapButtonProps> = ({event, notifiable = false, us
     </Button>
   );
 };
-
-type ButtonScrapeEventLinkProps = {
-  eventId: string;
-  organizationId: string;
-} & UseButtonProps;
-
-/**
- * Variant dedicated to EventLink UI
- *
- * Since it relies on sendToBackground, it is aimed at content-scripts usage only
- * It also enforce styling to overcome styling issues in EventLink UI
- */
-export const ButtonScrapeEventLink = ({ eventId, organizationId, ...props }: ButtonScrapeEventLinkProps) => {
-  const [isFetching, setIsFetching] = useState(false);
-  const [event, setEvent] = useState({
-    // A faked event to avoid null checks
-    id: eventId,
-    organizer: {
-      id: organizationId
-    },
-    status: {
-      scrape: ScrapeStatus.NOT_STARTED
-    },
-    lastUpdated: null
-  })
-
-  useEffect(() => {
-    if (eventId) {
-      loadScrapeStatus();
-    }
-    return () => { }
-
-    async function loadScrapeStatus () {
-      setIsFetching(true);
-      try {
-        const recoveredEvent = await sendToBackground({ name: 'back/event-get', body: { eventId }});
-        if (recoveredEvent) {
-          setEvent(recoveredEvent);
-        }
-      } catch (error) {
-        console.error("Failed to fetch event status:", error);
-      }
-      setIsFetching(false);
-    }
-  }, [eventId]);
-
-  if (isFetching || !event) {
-    return
-  }
-
-  return (
-    <ButtonScrape
-      event={event}
-      notifiable={false}
-      useOnClick={true}
-      className="bg-blue-600 text-white rounded-md gap-2 hover:bg-blue-700 disabled:bg-gray-400 transition" {...props}
-    />
-  );
-}
 
 export default ButtonScrape;

--- a/src/resources/ui/components/event/container.tsx
+++ b/src/resources/ui/components/event/container.tsx
@@ -26,9 +26,6 @@ const EventContainer = () => {
         <h1 className="text-4xl font-bold font-mtg">{event.title} <span
           className="text-xl">{event.date.toLocaleDateString()}</span>
         </h1>
-        <div>
-          <ButtonScrape />
-        </div>
 
         <div className="flex items-center">
           <Switch id="mode-switch" isSelected={isSetupMode}

--- a/src/resources/ui/containers/event-calendar-action.tsx
+++ b/src/resources/ui/containers/event-calendar-action.tsx
@@ -1,7 +1,7 @@
 import React, { type FC } from "react"
-import { ButtonScrapeEventLink } from "~resources/ui/components/button.scrape"
 import type { PlasmoCSUIProps } from "plasmo"
 import Context from "~resources/eventlink/context"
+import ButtonScrape from "~resources/ui/components/button.scrape"
 
 const EventCalendarAction: FC<PlasmoCSUIProps> = ({ anchor }) => {
   const organizationId = Context.getOrganizationId(window.location.href)
@@ -20,8 +20,10 @@ const EventCalendarAction: FC<PlasmoCSUIProps> = ({ anchor }) => {
     return null;
   }
 
+  console.log("EventCalendarAction", eventId, organizationId)
+
   return (
-    <ButtonScrapeEventLink
+    <ButtonScrape
       eventId={eventId}
       organizationId={organizationId}
       className={"absolute mt-2 mr-2"}

--- a/src/resources/ui/containers/event-title-actions.tsx
+++ b/src/resources/ui/containers/event-title-actions.tsx
@@ -1,9 +1,7 @@
-import { HeroUIProvider } from "@heroui/system"
 import React, { useEffect, useState } from "react"
-import { ButtonScrapeEventLink } from "~resources/ui/components/button.scrape"
 import ButtonToggle from "~resources/ui/components/button.toggle"
 import Context from "~resources/eventlink/context"
-import { ToastProvider } from "@heroui/react"
+import ButtonScrape from "~resources/ui/components/button.scrape"
 
 const EventTitleActions = () => {
   const [eventId, setEventId] = useState(null)
@@ -18,7 +16,7 @@ const EventTitleActions = () => {
 
   return (
     <div className={"flex gap-2"}>
-      <ButtonScrapeEventLink organizationId={organizationId} eventId={eventId}/>
+      <ButtonScrape organizationId={organizationId} eventId={eventId}/>
       <ButtonToggle />
     </div>
   )


### PR DESCRIPTION
The source of the issue is the inclusion of scrape button in the event page, and the introduction of useless features that couldn’t work outside of eventlink