### PR TITLE
docs: Add GitHub issue templates for bug reports, feature requests, and tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Report a bug to help improve Scrap Trawler
+title: "[Bug] Short description of the bug"
+labels: bug
+assignees:
+---
+
+**Describe the bug**
+  A clear and concise description of what the bug is.
+  
+  **To Reproduce**
+Steps to reproduce the behavior:
+  1. Go to '...'
+  2. Click on '...'
+  3. Scroll down to '...'
+  4. See error
+  
+  **Expected behavior**
+  A clear and concise description of what you expected to happen.
+  
+  **Screenshots**
+  If applicable, add screenshots to help explain the problem.
+  
+  **Logs**
+  If possible, provide relevant logs or console output.
+  
+  **Environment (please complete the following information):**
+- OS: [e.g., Windows, macOS, Linux]
+- Browser: [e.g., Chrome, Firefox]
+- Scrap Trawler Version: [e.g., v0.1.0]
+  
+  **Additional context**
+  Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General Inquiry
+    url: https://github.com/Guibod/scrap-trawler/discussions
+    about: For questions or discussions unrelated to bugs or feature requests.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an idea for Scrap Trawler
+title: "[Feature] Short description of the feature"
+labels: enhancement
+assignees: 
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Example: "I'm always frustrated when [...]"
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context, screenshots, or mockups about the feature request here.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,21 @@
+---
+name: Task
+about: General tasks or enhancements
+title: "[Task] Short description of the task"
+labels: task
+assignees: 
+---
+
+**Objective**
+Describe what needs to be done and why.
+
+**Steps**
+- [ ] Step 1
+- [ ] Step 2
+- [ ] Step 3
+
+**Dependencies**
+Are there any dependencies related to this task?
+
+**Additional Notes**
+Add any extra information, related issues, or references here.


### PR DESCRIPTION
Closes #58 